### PR TITLE
Change getExecutedMigrationsName to use list instead of find

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -71,8 +71,8 @@ Adapter.prototype.getTemplatePath = function () {
 };
 
 Adapter.prototype.getExecutedMigrationNames = async function () {
-    const q = await this._conn.use(this._dbName).find({ selector: {} });
-    return q.docs.map(doc => doc._id);
+    const q = await this._conn.use(this._dbName).list()
+    return q.rows.map(doc => doc.id);
 };
 
 Adapter.prototype.markExecuted = async function (name) {


### PR DESCRIPTION
Once you exceed 25 migrations this adapter breaks as find queries in Couch DB have a default limit of 25. I've changed this to use the list API which returns all documents.